### PR TITLE
Add Implementation for drawRect and drawCircle Methods

### DIFF
--- a/projects/canvaskit/src/lib/config/context2d-renderer/context2d-renderer.ts
+++ b/projects/canvaskit/src/lib/config/context2d-renderer/context2d-renderer.ts
@@ -3,12 +3,39 @@ import { CanvasKit } from "../canvaskit.model";
 export class Context2dRenderer implements CanvasKit {
 
     drawRect(x: number, y: number, width: number, height: number): void {
-      throw new Error('Not implemented');
+        // Create a canvas context (replace 'canvas' with your actual canvas element)
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        if (ctx) {
+            // Set the fill color (e.g., red)
+            ctx.fillStyle = 'red';
+
+            // Draw the rectangle
+            ctx.fillRect(x, y, width, height);
+        } else {
+            throw new Error('Canvas context is not supported.');
+        }
     }
   
-    drawCircle(x: number, y: number, radius: number): void {
-      throw new Error('Not implemented');
+   drawCircle(x: number, y: number, radius: number): void {
+        // Create a canvas context (replace 'canvas' with your actual canvas element)
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        if (ctx) {
+            // Set the fill color (e.g., blue)
+            ctx.fillStyle = 'blue';
+
+            // Draw the circle
+            ctx.beginPath();
+            ctx.arc(x, y, radius, 0, 2 * Math.PI);
+            ctx.fill();
+        } else {
+            throw new Error('Canvas context is not supported.');
+        }
     }
+
   
     drawLine(x1: number, y1: number, x2: number, y2: number): void {
       throw new Error('Not implemented');


### PR DESCRIPTION
This PR implements the drawRect and drawCircle methods in the Context2dRenderer class. These methods enable the rendering of rectangles and circles on an HTML canvas element using the HTML5 Canvas API.

